### PR TITLE
Don't clobber existing `Object#send` method

### DIFF
--- a/ios-update-notifier.rb
+++ b/ios-update-notifier.rb
@@ -124,9 +124,9 @@ module UpdateNotifier
         exit(false)
       end
 
-      UpdateNotifier::Slack.send(notification_text, config['slack'])
-      UpdateNotifier::SMS.send(notification_text, config['sms'])
-      UpdateNotifier::SMTP.send(notification_text, config['smtp'])
+      UpdateNotifier::Slack.notify(notification_text, config['slack'])
+      UpdateNotifier::SMS.notify(notification_text, config['sms'])
+      UpdateNotifier::SMTP.notify(notification_text, config['smtp'])
     end
 
     def update_last_seen(date)

--- a/lib/slack.rb
+++ b/lib/slack.rb
@@ -1,6 +1,6 @@
 module UpdateNotifier
   class Slack
-    def self.send(notification_message, config)
+    def self.notify(notification_message, config)
       if config['enabled']
         post_hash = { text: notification_message }
 

--- a/lib/sms.rb
+++ b/lib/sms.rb
@@ -2,7 +2,7 @@ require 'twilio-ruby'
 
 module UpdateNotifier
   class SMS
-    def self.send(notification_message, config)
+    def self.notify(notification_message, config)
       if config['enabled']
         client = Twilio::REST::Client.new(config['twilio_account_sid'], config['twilio_auth_token'])
 

--- a/lib/smtp.rb
+++ b/lib/smtp.rb
@@ -2,7 +2,7 @@ require 'net/smtp'
 
 module UpdateNotifier
   class SMTP
-    def self.send(notification_message, config)
+    def self.notify(notification_message, config)
       if config['enabled']
         smtp = Net::SMTP.new(config['server'], config['port'])
 


### PR DESCRIPTION
Just a little naming nit.

It's probably best not to clobber the existing Object#send method in case it
eventually needs to get used.

